### PR TITLE
Fix usage example for `product-pipeline`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Running the `product-pipeline`
 
 .. code-block:: console
 
-    fly -t us-east-playground set-pipeline -c product-pipeline/pipeline.yml -l product-pipeline/common.yml -l product-pipeline/pas_srt.yml -p install-pas-srt
+    fly -t us-east-playground set-pipeline -c product-pipeline/pipeline.yml -l product-pipeline/common.yml -l product-pipeline/azure/pas_srt.yml -p install-pas-srt
 
 2. Profit
 


### PR DESCRIPTION
This commit fixes the guidance in the README for using the
`product-pipeline`. The parent directory of the tile parameters was
previously absent from the example.